### PR TITLE
lsp,ui: do not attach lsp clients

### DIFF
--- a/lua/calltree/lsp/util.lua
+++ b/lua/calltree/lsp/util.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+M.multi_client_request = function(clients, method, params, handler, bufnr)
+    for _, client in ipairs(clients) do
+        if not client.supports_method(method) then
+            goto continue
+        end
+        client.request(method, params, handler, bufnr)
+        ::continue::
+    end
+end
+
+return M


### PR DESCRIPTION
previous to this commit the calltree buffer would attach active lsp
clients.

this was for an initial idea which never panned out, but also causes
issues as the LSP think the calltree buffer is a valid source file, it
is not.

additionally, this pr fixes a few bad variable references in ui.lua
w/r/t config.

closes: #2

Signed-off-by: ldelossa <louis.delos@gmail.com>