### PR TITLE
tree: unique keys

### DIFF
--- a/lua/calltree/tree.lua
+++ b/lua/calltree/tree.lua
@@ -32,8 +32,23 @@ function M.Node.new(name, depth, call_hierarchy_obj, kind, references)
         kind=kind,
         references=references
     }
+    node.key = M.Node.keyify(node)
     setmetatable(node, M.Node.mt)
     return node
+end
+
+-- keyify creates a key for a node
+--
+-- node : tree.Node - the node a key is being created
+-- for
+--
+-- returns:
+--  string - the key
+function M.Node.keyify(node)
+    local key = node.name .. ":"
+        .. node.call_hierarchy_obj.uri .. ":"
+        .. node.call_hierarchy_obj.range.start.line
+    return key
 end
 
 -- eq perfoms a recursive comparison
@@ -128,7 +143,7 @@ function M.add_node(parent,  children)
     -- lookup parent node in depth tree (faster then tree diving.)
     local pNode = nil
     for _, node in pairs(M.depth_table[parent.depth]) do
-        if node.name == parent.name then
+        if node.key == parent.key then
             pNode = node
             break
         end
@@ -193,7 +208,7 @@ function M.remove_subtree(node, root)
         local dt = M.depth_table[node.depth]
         local nw_dt = {}
         for _, dt_node in ipairs(dt) do
-            if dt_node.name ~= node.name then
+            if dt_node.key ~= node.key then
                 table.insert(nw_dt, dt_node)
             end
         end

--- a/lua/calltree/ui.lua
+++ b/lua/calltree/ui.lua
@@ -93,8 +93,7 @@ end
 -- position
 M.collapse = function()
     local linenr = vim.api.nvim_win_get_cursor(M.win_handle)
-    local line   = vim.api.nvim_get_current_line()
-    local node   = marshal.marshal_line(line)
+    local node   = marshal.marshal_line(linenr)
     if node == nil then
         return
     end
@@ -154,8 +153,7 @@ end
 -- expand will expand a symbol at the current cursor position
 M.expand = function()
     local linenr = vim.api.nvim_win_get_cursor(M.win_handle)
-    local line   = vim.api.nvim_get_current_line()
-    local node = marshal.marshal_line(line)
+    local node = marshal.marshal_line(linenr)
     if node == nil then
         return
     end
@@ -177,8 +175,8 @@ end
 -- the cursor, creating a calltree with the symbol
 -- as root.
 M.focus = function()
-    local line = vim.api.nvim_get_current_line()
-    local node = marshal.marshal_line(line)
+    local linenr = vim.api.nvim_win_get_cursor(M.win_handle)
+    local node = marshal.marshal_line(linenr)
     if node == nil then
         return
     end
@@ -229,8 +227,8 @@ end
 -- switch_direction will focus the symbol under the
 -- cursor and then invert the call hierarchy direction.
 M.switch_direction = function()
-    local line = vim.api.nvim_get_current_line()
-    local node = marshal.marshal_line(line)
+    local linenr = vim.api.nvim_win_get_cursor(M.win_handle)
+    local node = marshal.marshal_line(linenr)
     if node == nil then
         return
     end
@@ -253,8 +251,8 @@ end
 -- jump will jump to the source code location of the
 -- symbol under the cursor.
 M.jump = function()
-    local line = vim.api.nvim_get_current_line()
-    local node = marshal.marshal_line(line)
+    local linenr = vim.api.nvim_win_get_cursor(M.win_handle)
+    local node = marshal.marshal_line(linenr)
     if node == nil then
         return
     end
@@ -276,8 +274,8 @@ end
 -- under the cursor.
 M.hover = function()
     ui_buf.close_all_popups()
-    local line = vim.api.nvim_get_current_line()
-    local node = marshal.marshal_line(line)
+    local linenr = vim.api.nvim_win_get_cursor(M.win_handle)
+    local node = marshal.marshal_line(linenr)
     if node == nil then
         return
     end
@@ -297,8 +295,8 @@ end
 -- showing more information.
 M.details = function()
     ui_buf.close_all_popups()
-    local line = vim.api.nvim_get_current_line()
-    local node = marshal.marshal_line(line)
+    local linenr = vim.api.nvim_win_get_cursor(M.win_handle)
+    local node = marshal.marshal_line(linenr)
     if node == nil then
         return
     end


### PR DESCRIPTION
to get around #10 each node in the tree now has a unique key.

marshaling the tree is updated to cache the node at all given lines every
time write_tree is called.

marshaling a line is greatly simplified and just looks at the cached now
to understand which node is being selected.

closes #10

Signed-off-by: ldelossa <louis.delos@gmail.com>