### PR TITLE
ui,tree: use workspace symbol if possible

### DIFF
--- a/lua/calltree/lsp/handlers.lua
+++ b/lua/calltree/lsp/handlers.lua
@@ -1,5 +1,6 @@
 local tree = require('calltree.tree')
 local ui = require('calltree.ui')
+local lsp_util = require('calltree.lsp.util')
 
 local M = {}
 
@@ -35,6 +36,9 @@ M.ch_lsp_handler = function(direction)
         ctx.params.item,
         ctx.params.item.kind)
 
+        -- try to resolve the workspace symbol for root.
+        root.symbol = lsp_util.symbol_from_node(ui.active_lsp_clients, root, ui.invoking_win_handle)
+
         -- create the root's children nodes via the response array.
         local children = {}
         for _, call_hierarchy_call in pairs(result) do
@@ -45,6 +49,8 @@ M.ch_lsp_handler = function(direction)
              call_hierarchy_call[direction].kind,
              call_hierarchy_call.fromRanges
           )
+          -- try to resolve the workspace symbol for child
+          child.symbol = lsp_util.symbol_from_node(ui.active_lsp_clients, child, ui.invoking_win_handle)
           table.insert(children, child)
         end
 

--- a/lua/calltree/lsp/util.lua
+++ b/lua/calltree/lsp/util.lua
@@ -10,7 +10,7 @@ M.multi_client_request = function(clients, method, params, handler, bufnr)
     end
 end
 
-function M.relative_path_from_uri(uri) 
+function M.relative_path_from_uri(uri)
     local cwd = vim.fn.getcwd()
     local uri_path = vim.fn.substitute(uri, "file://", "", "")
     local idx = vim.fn.stridx(uri_path, cwd)
@@ -20,6 +20,50 @@ function M.relative_path_from_uri(uri)
         return uri_path, false
     end
     return vim.fn.substitute(uri_path, cwd .. "/", "", ""), true
+end
+
+-- symbol_from_node attempts to extract the workspace
+-- symbol the node represents.
+--
+-- clients : table - all active lsp clients
+--
+-- node : tree.Node - the node which we are resolving
+-- a symbol for.
+--
+-- bufnr : buffer_handle - the calltree buffer handle
+--
+-- returns:
+--  table - the SymbolInformation LSP structure
+--  https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#symbolInformation
+function M.symbol_from_node(clients, node, bufnr)
+    local params = {
+        query = node.name,
+    }
+    for _, client in ipairs(clients) do
+        if not client.supports_method("workspace/symbol") then
+            goto continue
+        end
+        -- not all LSPs are optimized, specially ones in early development, set
+        -- this timeout high.
+        local out = client.request_sync("workspace/symbol", params, 5000, bufnr)
+        if out == nil then
+            goto continue
+        end
+        if out.err ~= nil or (out.result == nil or #out.result <= 0) then
+            goto continue
+        end
+        for _, res in ipairs(out.result) do
+            if
+                res.uri == node.uri and
+                res.location.range.start.line ==
+                node.call_hierarchy_obj.range.start.line
+            then
+                return res
+            end
+        end
+        ::continue::
+    end
+    return nil
 end
 
 return M

--- a/lua/calltree/ui.lua
+++ b/lua/calltree/ui.lua
@@ -139,6 +139,8 @@ local function ch_expand_handler(node, linenr, direction)
                 call_hierarchy_call[direction].kind,
                 call_hierarchy_call.fromRanges
             )
+            -- try to resolve the workspace symbol for child
+            child.symbol = lsp_util.symbol_from_node(M.active_lsp_clients, child, M.buffer_handle)
             table.insert(children, child)
         end
 
@@ -201,6 +203,8 @@ local function ch_switch_handler(direction)
         0,
         ctx.params.item,
         ctx.params.item.kind)
+        -- try to resolve the workspace symbol for root
+        root.symbol = lsp_util.symbol_from_node(M.active_lsp_clients, child, M.buffer_handle)
 
         -- create the root's children nodes via the response array.
         local children = {}
@@ -212,6 +216,8 @@ local function ch_switch_handler(direction)
              call_hierarchy_call[direction].kind,
              call_hierarchy_call.fromRanges
           )
+          -- try to resolve the workspace symbol for child
+          child.symbol = lsp_util.symbol_from_node(M.active_lsp_clients, child, M.buffer_handle)
           table.insert(children, child)
         end
 

--- a/lua/calltree/ui/marshal.lua
+++ b/lua/calltree/ui/marshal.lua
@@ -31,7 +31,17 @@ function M.marshal_node(node)
         glyph = M.glyphs["collapsed"]
     end
 
-    local kind = vim.lsp.protocol.SymbolKind[node.kind]
+    -- prefer using workspace symbol details if available.
+    -- fallback to callhierarchy object details.
+    local name = ""
+    local kind = ""
+    if node.symbol ~= nil then
+        name = node.symbol.name
+        kind = vim.lsp.protocol.SymbolKind[node.symbol.kind]
+    else
+        name = node.name
+        kind = vim.lsp.protocol.SymbolKind[node.kind]
+    end
 
     -- add spacing up to node's depth
     for _=1, node.depth do
@@ -39,10 +49,10 @@ function M.marshal_node(node)
     end
 
     -- ▶ Func1
-    str = str .. glyph .. " " .. node.name
+    str = str .. glyph .. " " .. name
     if ct.config.icons ~= "none" then
-        -- ▶ Func1[]
-        str = str .. "[" .. ct.active_icon_set[kind] .. "]" .. " "
+        -- ▶ Func1 []
+        str = str .. " " .. "[" .. ct.active_icon_set[kind] .. "]" .. " "
     else
         -- ▶ Func1 • [Function]
         str = str .. M.glyphs.separator .. " " .. "[" .. kind .. "]" .. " "
@@ -52,7 +62,7 @@ function M.marshal_node(node)
         ct.config.layout == "top" then
         -- now we got all the room in the world, add detail
         path = lsp_util.relative_path_from_uri(node.call_hierarchy_obj.uri)
-        -- ▶ Func1[] • relative/path/to/file
+        -- ▶ Func1 [] • relative/path/to/file
         -- or
         -- ▶ Func1 • [Function] • relative/path/to/file
         str = str .. M.glyphs.separator .. " " .. path


### PR DESCRIPTION
after researching #10 a bit more I found that certain LSPs (gopls here)
provides more accurate symbol information via a workspace symbol query.

it would be nice to receieve the same symbol info regardless of the lsp
method being used. see: https://github.com/golang/go/issues/49690

this pr now resolves the workspace symbol for all call hierarchy items
placed into the tree.

this is a bit slower (with gopls anyway) on start, however I've found
that after some caching the results are snappy.

Signed-off-by: ldelossa <louis.delos@gmail.com>