### PR TITLE
themeing: provide default highlights

### DIFF
--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -191,6 +191,8 @@ The config table is described below:
         -- "nerd"           - Use Nerd font icon set for symbol types (requires patched font)
         -- "codicon"        - Use VSCode codicon icon set for symbol types (requires patched font)
         icons = "none",
+        -- disables highlights in the calltree UI completely.
+        no_hls = false,
         -- user provided icon highlight overrides. 
         -- see *calltree-icon-highlights*
         icon_highlights = {}
@@ -201,6 +203,18 @@ The config table is described below:
 
 ====================================================================================
 HIGHLIGHTS                                                     *calltree-highlights*
+
+A default set of highlights will be applied as long as "no_hls=false" is provided 
+in the config (this is the default setting). 
+
+Flipping this settings to true will disable all highlights (accept for jumps).
+
+The default set of highlights may not work for your color scheme, therefore its
+possible to theme calltree further. 
+
+The default higlights will stay in sync with "https://github.com/ldelossa/vimdark"
+
+See *calltree-icon-highlights* and *calltree-ui-highlights* for more info.
 
                                                           *calltree-icon-highlights*
 Each icon in the calltree UI can have its own highlight applied to it. 

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -7,9 +7,69 @@ M.config = {
     auto_open = false,
     jump_mode = "invoking",
     icons = "none",
+    no_hls = false,
     icon_highlights = {},
     hls = {}
 }
+
+function _setup_default_highlights() 
+    local dark = {
+        CTBoolean              = 'hi CTBoolean                guifg=#0087af guibg=None',
+        CTConstant             = 'hi CTConstant               guifg=#0087af guibg=None',
+        CTConstructor          = 'hi CTConstructor            guifg=#4DC5C6 guibg=None',
+        CTField                = 'hi CTField                  guifg=#0087af guibg=None',
+        CTFunction             = 'hi CTFunction               guifg=#988ACF guibg=None',
+        CTMethod               = 'hi CTMethod                 guifg=#0087af guibg=None',
+        CTNamespace            = 'hi CTNamespace              guifg=#87af87 guibg=None',
+        CTNumber               = 'hi CTNumber                 guifg=#9b885c guibg=None',
+        CTOperator             = 'hi CTOperator               guifg=#988ACF guibg=None',
+        CTParameter            = 'hi CTParameter              guifg=#988ACF guibg=None',
+        CTParameterReference   = 'hi CTParameterReference     guifg=#4DC5C6 guibg=None',
+        CTString               = 'hi CTString                 guifg=#af5f5f guibg=None',
+        CTSymbol               = 'hi CTSymbol                 guifg=#87afd7 gui=underline',
+        CTSymbolDetail         = 'hi CTSymbolDetail           ctermfg=024 cterm=italic guifg=#988ACF gui=italic',
+        CTSymbolJump           = 'hi CTSymbolJump             ctermfg=015 ctermbg=110 cterm=italic,bold,underline   guifg=#464646 guibg=#87afd7 gui=italic,bold',
+        CTSymbolJumpRefs       = 'hi CTSymbolJumpRefs         ctermfg=015 ctermbg=110 cterm=italic,bold,underline   guifg=#464646 guibg=#9b885c gui=italic,bold',
+        CTType                 = 'hi CTType                   guifg=#9b885c guibg=None',
+        CTURI                  = 'hi CTURI                    guifg=#988ACF guibg=None',
+    }
+    local light = {
+        CTBoolean               = 'hi CTBoolean                guifg=#005f87 guibg=None',
+        CTConstant              = 'hi CTConstant               guifg=#005f87 guibg=None',
+        CTConstructor           = 'hi CTConstructor            guifg=#9b885c guibg=None',
+        CTField                 = 'hi CTField                  guifg=#005f87 guibg=None',
+        CTFunction              = 'hi CTFunction               guifg=#806CCF guibg=None',
+        CTMethod                = 'hi CTMethod                 guifg=#005f87 guibg=None',
+        CTNamespace             = 'hi CTNamespace              guifg=#87af87 guibg=None',
+        CTNumber                = 'hi CTNumber                 guifg=#9b885c guibg=None',
+        CTOperator              = 'hi CTOperator               guifg=#806CCF guibg=None',
+        CTParameter             = 'hi CTParameter              guifg=#806CCF guibg=None',
+        CTParameterReference    = 'hi CTParameterReference     guifg=#268889 guibg=None',
+        CTString                = 'hi CTString                 guifg=#af5f5f guibg=None',
+        CTSymbol                = 'hi CTSymbol                 guifg=#806CCF gui=underline',
+        CTSymbolDetail          = 'hi CTSymbolDetail           ctermfg=024 cterm=italic guifg=#005f87 gui=italic',
+        CTSymbolJump            = 'hi CTSymbolJump             ctermfg=015 ctermbg=110 cterm=italic,bold,underline   guifg=#464646 guibg=#87afd7 gui=italic,bold',
+        CTSymbolJumpRefs        = 'hi CTSymbolJumpRefs         ctermfg=015 ctermbg=110 cterm=italic,bold,underline   guifg=#464646 guibg=#9b885c gui=italic,bold',
+        CTType                  = 'hi CTType                   guifg=#268889 guibg=None',
+        CTURI                   = 'hi CTURI                    guifg=#806CCF guibg=None',
+    }
+    local bg = vim.api.nvim_get_option("background")
+    if bg == "dark" then
+        print("here - dark")
+        for hl_name, hl in pairs(dark) do
+            if not vim.fn.hlexists(hl_name) == 0 then
+                vim.cmd(hl)
+            end
+        end
+    end
+    if bg == "light" then
+        for hl_name, hl in pairs(light) do
+            if vim.fn.hlexists(hl_name) == 0 then
+                vim.cmd(hl)
+            end
+        end
+    end
+end
 
 function M.setup(user_config)
     -- hijack the normal lsp handlers
@@ -68,6 +128,11 @@ function M.setup(user_config)
         if M.config.icons == "nerd" then
             M.active_icon_set = M.nerd
         end
+    end
+
+    -- setup default highlights
+    if not M.config.no_hls then
+        _setup_default_highlights()
     end
 
     -- automatically open the ui elements on buf enters.

--- a/lua/calltree/ui/window.lua
+++ b/lua/calltree/ui/window.lua
@@ -159,14 +159,16 @@ function M._setup_window(current_layout, desired_layout, ui_state)
         vim.api.nvim_win_set_option(ui_state[win_handle_to_set], 'wrap', false)
 
         ::continue::
-        -- set configured icon highlights
-        if ct.active_icon_set ~= nil then
-            for icon, hl in pairs(ct.icon_hls) do
-                vim.cmd(string.format("syn match %s /%s/", hl, ct.active_icon_set[icon]))
+        if not config.no_hls then
+            -- set configured icon highlights
+            if ct.active_icon_set ~= nil then
+                for icon, hl in pairs(ct.icon_hls) do
+                    vim.cmd(string.format("syn match %s /%s/", hl, ct.active_icon_set[icon]))
+                end
             end
+            -- set configured symbol highlight
+            vim.cmd(string.format("syn match %s /%s/", ct.hls.SymbolHL, [[\w]]))
         end
-        -- set configured symbol highlight
-        vim.cmd(string.format("syn match %s /%s/", ct.hls.SymbolHL, [[\w]]))
     end
 end
 


### PR DESCRIPTION
closes #21

this commit adds default highlights to calltree.

all default highlights can be overwriten.

a config option "no_hls" is added to disable highlights all together.

Signed-off-by: ldelossa <louis.delos@gmail.com>