### PR TITLE
ui: indentation improvemnts

### DIFF
--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -197,7 +197,10 @@ The config table is described below:
         no_hls = false,
         -- user provided icon highlight overrides. 
         -- see *calltree-icon-highlights*
-        icon_highlights = {}
+        icon_highlights = {},
+        -- bool which enables or diables indentation guides in the UI.
+        -- defaults to true.
+        indent_guides = true,
         -- user provided UI highlights.
         -- see *calltree-ui-highlights*
         hls = {}

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -8,6 +8,7 @@ M.config = {
     jump_mode = "invoking",
     icons = "none",
     no_hls = false,
+    indent_guides = true,
     icon_highlights = {},
     hls = {}
 }
@@ -196,6 +197,8 @@ M.nerd = {
     Unit            = "塞",
     Value           = "",
     Variable        = "",
+    Expanded        = "",
+    Collapsed       = "",
 }
 
 M.codicons = {
@@ -232,6 +235,8 @@ M.codicons = {
     Unit            = "",
     Value           = "",
     Variable        = "",
+    Expanded        = "",
+    Collapsed       = "",
 }
 
 M.icon_hls = {


### PR DESCRIPTION
this commit adds adds indentation guides and further padding between the
expanded/collapsed glyph and the symbol type icon/text.

this commit also fixes a bug where node.symbol was being checked instead
of node.call_hierarchy_item.

closes #24

Signed-off-by: ldelossa <louis.delos@gmail.com>