### PR TITLE
perf: async symbol gathering

### DIFF
--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -201,6 +201,21 @@ The config table is described below:
         -- user provided UI highlights.
         -- see *calltree-ui-highlights*
         hls = {}
+        -- some LSP's will provide symbols with different names depending on
+        -- the method called. 
+        --
+        -- if resolve_symbols is set to true a workspace symbol request will
+        -- be made for any responses from LSP's, providing clearer information 
+        -- for symbols in the calltree.
+        --
+        -- this will cause the UI to open slower, tho the symbol requests are 
+        -- async so it will not block the editor.
+        -- for full context see: 
+        -- https://github.com/golang/go/issues/49690#issuecomment-975902067
+        --
+        -- set this to false for large codebases to speed up opening
+        -- the calltree.
+        resolve_symbols = true
     }
 
 ====================================================================================

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -9,7 +9,8 @@ M.config = {
     icons = "none",
     no_hls = false,
     icon_highlights = {},
-    hls = {}
+    hls = {},
+    resolve_symbols = true
 }
 
 function _setup_default_highlights() 


### PR DESCRIPTION
LSPs may return different results depending on the method being
requested.

for instance gopls will return no receiver name when a call hierarchy
request is made, but will when a workspace symbol request is made.

to work around this we make a workspace symbol request for each call
hierarchy item returned when a calltree is invoked.

this proved to be very slow when done sync so this commit makes it
async using lua coroutines.

Signed-off-by: ldelossa <louis.delos@gmail.com>