### PR TITLE
ui: allow resizing via arrow keys

### DIFF
--- a/lua/calltree/handlers.lua
+++ b/lua/calltree/handlers.lua
@@ -52,8 +52,10 @@ function M.calltree_expand_handler(node, linenr, direction, ui_state)
             lsp_util.gather_symbols_async(node, children, ui_state, function()
                 tree.add_node(ui_state.calltree_handle, node, children)
                 tree.write_tree(ui_state.calltree_handle, ui_state.calltree_buf)
+                vim.api.nvim_win_set_cursor(ui_state.calltree_win, linenr)
                 ui.open_calltree()
             end)
+            vim.api.nvim_win_set_cursor(ui_state.calltree_win, linenr)
             return
         end
 

--- a/lua/calltree/ui/buffer.lua
+++ b/lua/calltree/ui/buffer.lua
@@ -1,3 +1,4 @@
+local config = require('calltree').config
 local M = {}
 
 -- close_all_popups is a convenience function to close any
@@ -7,6 +8,31 @@ local M = {}
 function M.close_all_popups()
     require('calltree.ui.hover').close_hover_popup()
     require('calltree.ui.details').close_details_popup()
+end
+
+local function map_resize_keys(buffer_handle, opts) 
+    local l = config.layout
+    if l == "top" or l == "bottom"  then
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Right>", ":vert resize +5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Left>", ":vert resize -5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Up>", ":resize +5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Down>", ":resize -5<cr>", opts)
+    elseif l == "bottom" then
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Right>", ":vert resize +5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Left>", ":vert resize -5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Down>", ":resize +5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Up>", ":resize -5<cr>", opts)
+    elseif l == "left" then
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Up>", ":resize +5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Down>", ":resize -5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Left>", ":vert resize -5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Right>", ":vert resize +5<cr>", opts)
+    elseif l == "right" then
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Up>", ":resize +5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Down>", ":resize -5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Left>", ":vert resize +5<cr>", opts)
+        vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Right>", ":vert resize -5<cr>", opts)
+    end
 end
 
 -- _setup_buffer performs an idempotent creation
@@ -62,6 +88,7 @@ function M._setup_buffer(name, buffer_handle, tab)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "d", ":CTDetails<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":CTSwitch<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "?", ":lua require('calltree.ui').help(true)<CR>", opts)
+    map_resize_keys(buffer_handle, opts)
 
     return buffer_handle
 end

--- a/lua/calltree/ui/help_buffer.lua
+++ b/lua/calltree/ui/help_buffer.lua
@@ -24,13 +24,14 @@ function M._setup_help_buffer(help_buf_handle)
             "press 'c' to close",
             "",
             "KEYMAP:",
-            "zo      - expand a symbol",
-            "zc      - collapse a symbol",
-            "return  - jump to symbol",
-            "f       - focus the tree on this symbol (call hierarhies)",
-            "s       - switch the symbol from incoming/outgoing calls (call hierarchies)",
-            "i       - show hover info for symbol",
-            "d       - show symbol details"
+            "zo                 - expand a symbol",
+            "zc                 - collapse a symbol",
+            "return             - jump to symbol",
+            "f                  - focus the tree on this symbol (call hierarhies)",
+            "s                  - switch the symbol from incoming/outgoing calls (call hierarchies)",
+            "i                  - show hover info for symbol",
+            "d                  - show symbol details",
+            "Up,Down,Right,Left - resize calltree windows"
         }
         vim.api.nvim_buf_set_lines(help_buf_handle, 0, #lines, false, lines)
     end


### PR DESCRIPTION
this commit maps the arrow keys to resize commands for calltree ui
buffers.

a few bug fixes along th way as well.

Signed-off-by: ldelossa <louis.delos@gmail.com>
