### PR TITLE
ui: auto highlight symboltree

### DIFF
--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -244,7 +244,10 @@ The config table is described below:
         resolve_symbols = true
         -- if set to true calling LSP functions which trigger calltree UI 
         -- will open the unified panel. see *calltree-usage* for details.
-        open_panel = false
+        unified_panel = false
+        -- automatic highlighting and window position updates when 
+        -- navigating the symboltree UI. Set to false to disable.
+        auto_highlight = true
     }
 
 ====================================================================================

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -12,7 +12,8 @@ M.config = {
     icon_highlights = {},
     hls = {},
     resolve_symbols = true,
-    unified_panel = false
+    unified_panel = false,
+    auto_highlight = true
 }
 
 function _setup_default_highlights() 

--- a/lua/calltree/handlers.lua
+++ b/lua/calltree/handlers.lua
@@ -53,7 +53,6 @@ function M.calltree_expand_handler(node, linenr, direction, ui_state)
                 tree.add_node(ui_state.calltree_handle, node, children)
                 tree.write_tree(ui_state.calltree_handle, ui_state.calltree_buf)
                 vim.api.nvim_win_set_cursor(ui_state.calltree_win, linenr)
-                ui.open_calltree()
             end)
             vim.api.nvim_win_set_cursor(ui_state.calltree_win, linenr)
             return
@@ -101,10 +100,18 @@ function M.calltree_switch_handler(direction, ui_state)
           table.insert(children, child)
         end
 
+        if config.resolve_symbols then
+            lsp_util.gather_symbols_async(root, children, ui_state, function()
+                tree.add_node(ui_state.calltree_handle, root, children)
+                tree.write_tree(ui_state.calltree_handle, ui_state.calltree_buf)
+                vim.api.nvim_buf_set_name(ui_state.calltree_buf, direction_map[direction].buf_name .. ":" .. ui_state.calltree_tab)
+            end)
+            return
+        end
+
         -- add the new root, its children, and rewrite the
         -- tree (will open the calltree ui if necessary).
         tree.add_node(ui_state.calltree_handle, root, children)
-
         tree.write_tree(ui_state.calltree_handle, ui_state.calltree_buf)
         vim.api.nvim_buf_set_name(ui_state.calltree_buf, direction_map[direction].buf_name .. ":" .. ui_state.calltree_tab)
     end

--- a/lua/calltree/ui.lua
+++ b/lua/calltree/ui.lua
@@ -9,6 +9,7 @@ local deets = require('calltree.ui.details')
 local hover = require('calltree.ui.hover')
 local tree  = require('calltree.tree.tree')
 local handlers = require('calltree.handlers')
+local au_hl = require('calltree.ui.auto_highlights')
 
 local M = {}
 
@@ -457,6 +458,24 @@ M.details = function()
         direction = ui_state.calltree_dir
     end
     deets.details_popup(node, direction)
+end
+
+M.auto_highlight = function(set)
+    local buf    = vim.api.nvim_get_current_buf()
+    local win    = vim.api.nvim_get_current_win()
+    local tab    = vim.api.nvim_win_get_tabpage(win)
+    local linenr = vim.api.nvim_win_get_cursor(win)
+    local tree_type   = M.get_type_from_buf(tab, buf)
+    local tree_handle = M.get_tree_from_buf(tab, buf)
+    local node = marshal.marshal_line(linenr, tree_handle)
+    if node == nil then
+        return
+    end
+    if tree_type ~= "symboltree" then
+        return
+    end
+    local ui_state  = M.ui_state_registry[tab]
+    au_hl.highlight(node, set, ui_state)
 end
 
 -- dumptree will dump the tree datastructure to a

--- a/lua/calltree/ui/auto_highlights.lua
+++ b/lua/calltree/ui/auto_highlights.lua
@@ -1,0 +1,54 @@
+local lsp_util = require('calltree.lsp.util')
+local ct = require('calltree')
+
+local M = {}
+
+-- the current highlight used for auto-highlighting
+M.higlight_ns = vim.api.nvim_create_namespace("calltree-hl")
+
+-- highlight is used specifically with the symboltree UI.
+-- sets a highlight for the provided symboltree node and sets
+-- the cursor to the start of the symbol.
+--
+-- this function always targets the "invoking_symboltree_win" in the ui
+-- state. this is because the symboltree UI always follows the last focused
+-- source code window in vim.
+--
+-- node : tree.tree.Node - the currently selected node in the symbol tree
+-- set : bool - whether to remove the highlight and immediately return
+-- ui_state : table - the current calltree ui_state provided by the ui
+-- module.
+function M.highlight(node, set, ui_state)
+    local buf = vim.api.nvim_win_get_buf(ui_state.invoking_symboltree_win)
+    vim.api.nvim_buf_clear_namespace(
+        buf,
+        M.higlight_ns,
+        0,
+        -1
+    )
+    if not set then
+        return
+    end
+
+    local location = lsp_util.resolve_location(node)
+    if location == nil then
+        return
+    end
+    local range = location.range
+
+    if range["end"] == nil then
+        return
+    end
+
+    vim.api.nvim_buf_add_highlight(
+        buf,
+        M.higlight_ns,
+        ct.hls.SymbolJumpHL,
+        range["start"].line,
+        range["start"].character,
+        range["end"].character
+    )
+    vim.api.nvim_win_set_cursor(ui_state.invoking_symboltree_win, {range["start"].line+1, 0})
+end
+
+return M

--- a/lua/calltree/ui/buffer.lua
+++ b/lua/calltree/ui/buffer.lua
@@ -10,7 +10,7 @@ function M.close_all_popups()
     require('calltree.ui.details').close_details_popup()
 end
 
-local function map_resize_keys(buffer_handle, opts) 
+local function map_resize_keys(buffer_handle, opts)
     local l = config.layout
     if l == "top" or l == "bottom"  then
         vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Right>", ":vert resize +5<cr>", opts)
@@ -77,6 +77,11 @@ function M._setup_buffer(name, buffer_handle, tab)
     vim.cmd("au BufWinLeave <buffer=" .. buffer_handle .. "> lua require('calltree.ui.jumps').set_jump_hl(false)")
     -- au to close popup with cursor moves or buffer is closed.
     vim.cmd("au CursorMoved,BufWinLeave,WinLeave <buffer=" .. buffer_handle .. "> lua require('calltree.ui.buffer').close_all_popups()")
+
+    if config.auto_highlight then
+        vim.cmd("au BufWinLeave,WinLeave <buffer=" .. buffer_handle .. "> lua require('calltree.ui').auto_highlight(false)")
+        vim.cmd("au CursorHold <buffer=" .. buffer_handle .. "> lua require('calltree.ui').auto_highlight(true)")
+    end
 
     -- set buffer local keymaps
     local opts = {silent=true}

--- a/lua/calltree/ui/marshal.lua
+++ b/lua/calltree/ui/marshal.lua
@@ -128,6 +128,12 @@ end
 -- returns:
 --   tree.Node - the marshaled tree.Node table.
 function M.marshal_line(linenr, tree)
+    if M.buf_line_map == nil then
+        return nil
+    end
+    if M.buf_line_map[tree] == nil then
+        return nil
+    end
     local node = M.buf_line_map[tree][linenr[1]]
     return node
 end

--- a/lua/calltree/ui/window.lua
+++ b/lua/calltree/ui/window.lua
@@ -7,7 +7,7 @@ local M = {}
 
 -- static_layout defines the order of calltree windows in
 -- the ui.
-local static_layout = {calltree=1, symboltree=2}
+local static_layout = {symboltree=1, calltree=2}
 
 -- type_to_ui_state_win is a helper map which maps the
 -- window type being opened to the win field on the ui_state.


### PR DESCRIPTION
this commit adds an option (defaults on) to auto highlight and auto move
the cursor to the selected symbol in the symbol tree.

Signed-off-by: ldelossa <louis.delos@gmail.com>
