### PR TITLE
ui: open directly to calltree ui elements

### DIFF
--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -148,8 +148,8 @@ function M.setup(user_config)
     vim.cmd([[au TextChanged,BufEnter,BufWritePost * lua require('calltree.ui').refresh_symbol_tree()]])
 
    -- setup commands
-   vim.cmd("command! CTOpen        lua require('calltree.ui').open_calltree()")
-   vim.cmd("command! STOpen        lua require('calltree.ui').open_symboltree()")
+   vim.cmd("command! CTOpen        lua require('calltree.ui').open_to('calltree')")
+   vim.cmd("command! STOpen        lua require('calltree.ui').open_to('symboltree')")
    vim.cmd("command! CTToggle      lua require('calltree.ui').toggle_panel()")
    vim.cmd("command! CTClose       lua require('calltree.ui').close_calltree()")
    vim.cmd("command! STClose       lua require('calltree.ui').close_symboltree()")

--- a/lua/calltree/lsp/handlers.lua
+++ b/lua/calltree/lsp/handlers.lua
@@ -68,20 +68,12 @@ M.ch_lsp_handler = function(direction)
         if config.resolve_symbols then
             lsp_util.gather_symbols_async(root, children, ui_state, function()
                 tree.add_node(ui_state.calltree_handle, root, children)
-                if config.unified_panel then
-                    ui.toggle_panel(true)
-                else
-                    ui.open_calltree()
-                end
+                ui.open_to("calltree")
             end)
             return
         end
         tree.add_node(ui_state.calltree_handle, root, children)
-        if config.unified_panel then
-            ui.toggle_panel(true)
-        else
-            ui.open_calltree()
-        end
+        ui.open_to("calltree")
    end
 end
 
@@ -121,11 +113,14 @@ M.ws_lsp_handler = function()
         ui_state.symboltree_handle = tree.new_tree("symboltree")
 
         -- create a synthetic document symbol to act as a root
+        local synthetic_range = {}
+        synthetic_range["start"] = {line=0,character=0}
+        synthetic_range["end"] = {line=0,character=0}
         local synthetic_root_ds = {
             name = lsp_util.relative_path_from_uri(ctx.params.textDocument.uri),
             kind = 1,
-            range = {start = {line = -1}}, -- provide this so keyify works in tree_node.add
-            selectionRange = {start = {line = -1}}, -- provide this so keyify works in tree_node.add
+            range = synthetic_range, -- provide this so keyify works in tree_node.add
+            selectionRange = synthetic_range, -- provide this so keyify works in tree_node.add
             children = result,
             uri = ctx.params.textDocument.uri,
             detail = "file"
@@ -138,7 +133,7 @@ M.ws_lsp_handler = function()
         if config.unified_panel then
             ui.toggle_panel(true)
         else
-            ui.open_symboltree()
+            ui._open_symboltree()
         end
     end
 end

--- a/lua/calltree/lsp/util.lua
+++ b/lua/calltree/lsp/util.lua
@@ -163,6 +163,10 @@ function M.gather_symbols_async_handler(node, co)
             coroutine.resume(co, nil)
             return
         end
+        if result == nil then
+            coroutine.resume(co, nil)
+            return
+        end
 
         local start_line, uri = "", ""
         if node.call_hierarchy_item ~= nil then

--- a/lua/calltree/ui/auto_highlights.lua
+++ b/lua/calltree/ui/auto_highlights.lua
@@ -19,7 +19,13 @@ M.higlight_ns = vim.api.nvim_create_namespace("calltree-hl")
 -- ui_state : table - the current calltree ui_state provided by the ui
 -- module.
 function M.highlight(node, set, ui_state)
+    if not vim.api.nvim_win_is_valid(ui_state.invoking_symboltree_win) then
+        return
+    end
     local buf = vim.api.nvim_win_get_buf(ui_state.invoking_symboltree_win)
+    if not vim.api.nvim_buf_is_valid(buf) then
+        return
+    end
     vim.api.nvim_buf_clear_namespace(
         buf,
         M.higlight_ns,


### PR DESCRIPTION
this commit reworks the CTOpen and STOpen commands.

now calling these commands will open the respective UI and jump
directly into it.

calling the same command from inside the calltree ui window will jump
back to the window which invoked it.

this is very useful when "jumping over" split windows such that the
symboltree does not unintentionally update with the outline of a buffer
between the intended buffer and the symbol outline window.

Signed-off-by: ldelossa <louis.delos@gmail.com>
