### PR TITLE
workflow: add smart closing of UI elements

### DIFF
--- a/lua/calltree/ui/buffer.lua
+++ b/lua/calltree/ui/buffer.lua
@@ -93,6 +93,7 @@ function M._setup_buffer(name, buffer_handle, tab)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "d", ":CTDetails<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":CTSwitch<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "?", ":lua require('calltree.ui').help(true)<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "c", ":lua require('calltree.ui')._smart_close()<CR>", opts)
     map_resize_keys(buffer_handle, opts)
 
     return buffer_handle

--- a/lua/calltree/ui/help_buffer.lua
+++ b/lua/calltree/ui/help_buffer.lua
@@ -31,6 +31,7 @@ function M._setup_help_buffer(help_buf_handle)
             "s                  - switch the symbol from incoming/outgoing calls (call hierarchies)",
             "i                  - show hover info for symbol",
             "d                  - show symbol details",
+            "c                  - close the current ui",
             "Up,Down,Right,Left - resize calltree windows"
         }
         vim.api.nvim_buf_set_lines(help_buf_handle, 0, #lines, false, lines)


### PR DESCRIPTION
this commit adds a keymap to all calltree ui buffers for closing the
element and jumping back to the window that invoked it (if it still
exists).

this is useful for workflows which do not use a unified panel but also
like to quickly hide the UI elements after browsing the call/symbol
tree.

Signed-off-by: ldelossa <louis.delos@gmail.com>
