### PR TITLE
ui,symboltree: source code tracking

### DIFF
--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -147,6 +147,9 @@ function M.setup(user_config)
     -- will keep the outline view up to date when moving around buffers.
     vim.cmd([[au TextChanged,BufEnter,BufWritePost * lua require('calltree.ui').refresh_symbol_tree()]])
 
+    -- will enable symboltree ui tracking with source code lines.
+    vim.cmd([[au CursorHold * lua require('calltree.ui').source_tracking()]])
+
    -- setup commands
    vim.cmd("command! CTOpen        lua require('calltree.ui').open_to('calltree')")
    vim.cmd("command! STOpen        lua require('calltree.ui').open_to('symboltree')")

--- a/lua/calltree/lsp/handlers.lua
+++ b/lua/calltree/lsp/handlers.lua
@@ -130,11 +130,25 @@ M.ws_lsp_handler = function()
 
         tree.add_node(ui_state.symboltree_handle, root, nil, true)
 
+        local cursor = nil
+        if vim.api.nvim_win_is_valid(ui_state.symboltree_win) then
+            cursor = vim.api.nvim_win_get_cursor(ui_state.symboltree_win)
+        end
+
         if config.unified_panel then
             ui.toggle_panel(true)
         else
             ui._open_symboltree()
         end
+        -- restore cursor if possible
+        if cursor ~= nil then
+           local count = vim.api.nvim_buf_line_count(ui_state.symboltree_buf)
+           if  count ~= nil
+               and vim.api.nvim_buf_is_valid(ui_state.symboltree_buf)
+               and vim.api.nvim_buf_line_count(ui_state.symboltree_buf) >= cursor[1] then
+                vim.api.nvim_win_set_cursor(ui_state.symboltree_win, cursor)
+            end
+       end
     end
 end
 


### PR DESCRIPTION
this commit implements tracking between source code and the symboltree
ui.

now, both the symboltree and the source code will track each other, such
that movement in one will update the other's cursor position and
auto highlights.

Signed-off-by: ldelossa <louis.delos@gmail.com>