### PR TITLE
usability: unified panel by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ require('calltree').setup({})
 
 ## Use it
 
-The setup function hooks directly into the "textDocument/incomingCalls", "textDocument/outgoingCalls", and "textDocument/documentSymbol" LSP handlers. 
+The setup function hooks directly into the "textDocument/incomingCalls", "textDocument/outgoingCalls" (calltress), and "textDocument/documentSymbol" (symboltree) LSP handlers. 
 
-To start a call tree use the LSP client just like you're used to:
+To start a calltree or a symboltree use the LSP client just like you're used to:
 
 ```
 :lua vim.lsp.buf.incoming_calls()
@@ -113,17 +113,14 @@ The UI works together and will always ensure a static layout with call hierarchy
 
 ## Unified Panel
 
-It's possible to treat Calltree.nvim's UI as a persistent but collapsible panel. 
+Calltree.nvim works as a unified panel on the left (or top/right/bottom when configured) of the editor windows. 
 
-This would be similar to VSCode and JetBrain IDEs, where an informational panel is present on the left, bottom, right, or top of the editor depending on configuration. 
+The unified panel will consist of the most recently created symboltree and/or calltree. 
+The panel can be toggled closed and open, once a LSP request has been made, with ":CTPanel".
 
-When enabling the unified panel, both the symboltree (document symbol outline) and the calltree (any recently requested call hierarchy outline) are always displayed together. 
+When inside the panel you can use the keybinding "h" to temporarily hide the Calltree.nvim UI element the cursor is inside. When you toggle the panel the hidden element will return. 
 
-The "CTPanel" command may be used to open and collapse the unified panel when desired. 
-
-The configuration options `unified_panel` and `auto_open_panel` can be set to true to ensure the unified panel is opened when LSP requests are made and the unified panel is opened on Neovim's start, respectively.
-
-The unified panel is completely opt-in. By keeping the `unified_panel` and `auto_open_panel` options false only the respectively Calltree.nvim UI elements will open when LSP requests are made. Furthermore, you can use ":CTPanel" freely without either option above set, if you'd like to "sometimes" use the unified panel without any constraints.
+If you'd like to permanently close a Calltree.nvim UI element (until another LSP request) from the panel use the ":CTClose" or ":STClose" commands. This closes and **removes** the tree from Calltree.nvim's memory. 
 
 ## Demo
 

--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -70,17 +70,14 @@ The calltree UI can be used as a unified panel or as individual elements.
 
                                                             *calltree-unified-panel*
 
-It's possible to treat Calltree.nvim's UI as a persistent but collapsible panel. 
+Calltree.nvim works as a unified panel on the left (or top/right/bottom when configured) of the editor windows. 
 
-This would be similar to VSCode and JetBrain IDEs, where an informational panel is present on the left, bottom, right, or top of the editor depending on configuration. 
+The unified panel will consist of any recently created symboltree or calltree. 
+The panel can be toggled closed and open (once a LSP request has been made) with "CTPanel".
 
-When enabling the unified panel, both the symboltree (document symbol outline) and the calltree (any recently requested call hierarchy outline) are always displayed together. 
+When inside the panel you can use the keybinding "h" to temporarily hide the Calltree.nvim UI element the cursor is inside. When you close and open the panel the hidden element will return. 
 
-The "CTPanel" command may be used to open and collapse the unified panel when desired. 
-
-The configuration options `unified_panel` and `auto_open_panel` can be set to true to ensure the unified panel is opened when LSP requests are made and the unified panel is opened on Neovim's start, respectively.
-
-The unified panel is completely opt-in. By keeping the `unified_panel` and `auto_open_panel` options false only the respectively Calltree.nvim UI elements will open when LSP requests are made. Furthermore, you can use ":CTPanel" freely without either option above set, if you'd like to "sometimes" use the unified panel without any constraints.
+If you'd like to permanently close a Calltree.nvim UI element (until another LSP request) from the panel use the "CTClose" or "STClose" commands. This closes and **removes** the tree from Calltree.nvim's memory. 
 
 From there check out *calltree-commands* to manipulate the calltree UI.
 
@@ -97,14 +94,19 @@ Calltree exports several commands for manipulating the calltree UI.
 
                                                                           *:CTClose*       
 :CTClose       
-    Closes the calltree window.
+    Closes the calltree window until another call hierarchy request is made.
                                                                            
 
                                                                          *:CTPanel*
 :CTPanel
-    Treats calltree as a persistent panel and toggles it open or close.
-    Using this command will always toggle both the symboltree and calltree
-    components as if they were a single unified panel.
+    Toggles the unified panel open and closed.
+    An LSP request must be made for the panel to toggle open.
+    When the panel is toggled closed the trees remain in memory and will
+    appear again when toggled open.
+
+    To remove a calltree or symboltree, such that toggling
+    does not show the tree again, use the CTClose or
+    STClose commands.
 
                                                                            *:STOpen*
 :STOpen                                         
@@ -114,7 +116,8 @@ Calltree exports several commands for manipulating the calltree UI.
 
                                                                           *:STClose*       
 :STClose       
-    Closes the symboltree window
+    Closes the symboltree window until another document symbols lsp
+    request is made.
 
                                                                          *:CTExpand*
 :CTExpand      
@@ -253,13 +256,6 @@ The config table is described below:
         -- set this to false for large codebases to speed up opening
         -- the calltree.
         resolve_symbols = true
-        -- if set to true calling LSP functions which trigger calltree UI 
-        -- will open the unified panel. see *calltree-usage* for details.
-        unified_panel = false
-        -- whether to automatically open the unified ui on start.
-        -- unified_panel need not be true to open the panel
-        -- on start.
-        auto_open_panel = false,
         -- automatic highlighting and window position updates when 
         -- navigating the symboltree UI. Set to false to disable.
         auto_highlight = true

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -11,8 +11,6 @@ M.config = {
     icon_highlights = {},
     hls = {},
     resolve_symbols = true,
-    unified_panel = false,
-    auto_open_panel = false,
     auto_highlight = true
 }
 
@@ -140,11 +138,6 @@ function M.setup(user_config)
     -- setup default highlights
     if not M.config.no_hls then
         _setup_default_highlights()
-    end
-
-    -- automatically open the ui elements on buf enters.
-    if M.config.auto_open then
-        vim.cmd([[au VimEnter * lua require('calltree.ui').toggle_panel()]])
     end
 
     -- will keep the outline view up to date when moving around buffers.

--- a/lua/calltree/lsp/handlers.lua
+++ b/lua/calltree/lsp/handlers.lua
@@ -42,6 +42,11 @@ M.ch_lsp_handler = function(direction)
         -- occur here.
         ui_state.invoking_calltree_win = vim.api.nvim_get_current_win()
 
+        -- remove existing tree from memory if exists
+        if ui_state.calltree_handle ~= nil then
+            tree.remove_tree(ui_state.calltree_handle)
+        end
+
         -- create a new tree
         ui_state.calltree_handle = tree.new_tree("calltree")
 
@@ -109,6 +114,11 @@ M.ws_lsp_handler = function()
 
         ui_state.invoking_symboltree_win = vim.api.nvim_get_current_win()
 
+        -- remove existing tree from memory is exists
+        if ui_state.symboltree_handle ~= nil then
+            tree.remove_tree(ui_state.symboltree_handle)
+        end
+
         -- create a new tree
         ui_state.symboltree_handle = tree.new_tree("symboltree")
 
@@ -135,11 +145,8 @@ M.ws_lsp_handler = function()
             cursor = vim.api.nvim_win_get_cursor(ui_state.symboltree_win)
         end
 
-        if config.unified_panel then
-            ui.toggle_panel(true)
-        else
-            ui._open_symboltree()
-        end
+        ui.toggle_panel(true)
+
         -- restore cursor if possible
         if cursor ~= nil then
            local count = vim.api.nvim_buf_line_count(ui_state.symboltree_buf)

--- a/lua/calltree/tree/tree.lua
+++ b/lua/calltree/tree/tree.lua
@@ -36,6 +36,14 @@ function M.get_tree(handle)
     return reg[handle]
 end
 
+-- remove_tree takes a call handle and removes
+-- the associated tree from memory.
+--
+-- handle : tree_handle - a valid handle to a tree
+function M.remove_tree(handle)
+    reg[handle] = nil
+end
+
 -- recursive_dpt_compute traverses the tree
 -- and flattens it into out depth_table
 --

--- a/lua/calltree/ui.lua
+++ b/lua/calltree/ui.lua
@@ -172,11 +172,7 @@ M.open_to = function(ui)
                 return
             end
         end
-        if config.unified_panel then
-            M.toggle_panel(true)
-        else
-            M._open_calltree()
-        end
+        M.toggle_panel(true)
         ui_state = M.ui_state_registry[ctx.tab]
         vim.api.nvim_set_current_win(ui_state.calltree_win)
     elseif ui == "symboltree" then
@@ -194,11 +190,7 @@ M.open_to = function(ui)
                 return
             end
         end
-        if config.unified_panel then
-            M.toggle_panel(true)
-        else
-            M._open_symboltree()
-        end
+        M.toggle_panel(true)
         ui_state = M.ui_state_registry[ctx.tab]
         vim.api.nvim_set_current_win(ui_state.symboltree_win)
     end
@@ -232,7 +224,11 @@ M._open_calltree = function()
     ui_win._open_window("calltree", ctx.state)
 end
 
--- close will close the calltree ui in the current tab.
+-- close will close the calltree ui in the current tab
+-- and remove the corresponding tree from memory.
+--
+-- use _smart_close if you simply want to hide a calltree
+-- element temporarily (not removing the tree from memory)
 M.close_calltree = function()
     local ctx = ui_req_ctx()
     if ctx.state.calltree_win ~= nil then
@@ -241,6 +237,10 @@ M.close_calltree = function()
         end
     end
     ctx.state.calltree_win = nil
+    if ctx.state.calltree_handle ~= nil then
+        tree.remove_tree(ctx.state.calltree_handle)
+        ctx.state.calltree_handle = nil
+    end
 end
 
 -- _smart_close is a convenience function which closes
@@ -248,6 +248,9 @@ end
 --
 -- useful when mapped to a buffer local key binding
 -- to quickly close the window after jumped too.
+--
+-- this function will not remove any tree from memory
+-- and is used to temporarily hide a UI element.
 M._smart_close = function()
     local ctx = ui_req_ctx()
     if ctx.tree_type == "calltree" then
@@ -318,6 +321,10 @@ M.refresh_symbol_tree = function()
 end
 
 -- close_symboltree will close the symboltree ui in the current tab.
+-- and remove the corresponding tree from memory.
+--
+-- use _smart_close if you simply want to hide a calltree
+-- element temporarily (not removing the tree from memory)
 M.close_symboltree = function()
     local ctx = ui_req_ctx()
     if ctx.state.symboltree_win ~= nil then
@@ -326,6 +333,10 @@ M.close_symboltree = function()
         end
     end
     ctx.state.symboltree_win = nil
+    if ctx.state.symboltree_handle ~= nil then
+        tree.remove_tree(ctx.state.symboltree_handle)
+        ctx.state.symboltree_handle = nil
+    end
 end
 
 -- toggle_panel will open and close the unified panel

--- a/lua/calltree/ui/buffer.lua
+++ b/lua/calltree/ui/buffer.lua
@@ -95,7 +95,7 @@ function M._setup_buffer(name, buffer_handle, tab)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "d", ":CTDetails<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "s", ":CTSwitch<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "?", ":lua require('calltree.ui').help(true)<CR>", opts)
-    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "c", ":lua require('calltree.ui')._smart_close()<CR>", opts)
+    vim.api.nvim_buf_set_keymap(buffer_handle, "n", "h", ":lua require('calltree.ui')._smart_close()<CR>", opts)
     map_resize_keys(buffer_handle, opts)
 
     return buffer_handle

--- a/lua/calltree/ui/help_buffer.lua
+++ b/lua/calltree/ui/help_buffer.lua
@@ -57,7 +57,7 @@ function M._setup_help_buffer(help_buf_handle)
             "s                  - switch the symbol from incoming/outgoing calls (call hierarchies)",
             "i                  - show hover info for symbol",
             "d                  - show symbol details",
-            "c                  - close the current ui",
+            "h                  - hide the current ui in the buffer, will appear again on panel toggle",
             "Up,Down,Right,Left - resize calltree windows"
         }
         vim.api.nvim_buf_set_lines(help_buf_handle, 0, #lines, false, lines)

--- a/lua/calltree/ui/window.lua
+++ b/lua/calltree/ui/window.lua
@@ -116,9 +116,18 @@ function M._toggle_panel(ui_state, keep_open)
     end
 
     -- we didn't find any open calltree windows, toggle
-    -- the pannel open
-    M._open_window("calltree", ui_state)
-    M._open_window("symboltree", ui_state)
+    -- the panel open
+    if 
+        ui_state.calltree_handle ~= nil
+    then
+        M._open_window("calltree", ui_state)
+    end
+    if 
+        ui_state.symboltree_handle ~= nil
+    then
+        M._open_window("symboltree", ui_state)
+    end
+
     vim.api.nvim_set_current_win(cur_win)
 end
 


### PR DESCRIPTION
this commit reworks the idea of an optional unified panel as the idea
was getting messy.

now, the UI always acts as a unified panel, one which supports
permanently closing the symboltree or calltree if desired.

initial cleaning of the in-memory trees take place in this pr but more
cleaning, such as on tab delete, will take place in a subsequent pr.

Signed-off-by: ldelossa <louis.delos@gmail.com>
