### PR TITLE
tree: cleanup trees when tab closed

### DIFF
--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -233,7 +233,7 @@ The config table is described below:
         indent_guides = true,
         -- user provided UI highlights.
         -- see *calltree-ui-highlights*
-        hls = {}
+        hls = {},
         -- some LSP's will provide symbols with different names depending on
         -- the method called. 
         --
@@ -248,10 +248,10 @@ The config table is described below:
         --
         -- set this to false for large codebases to speed up opening
         -- the calltree.
-        resolve_symbols = true
+        resolve_symbols = true,
         -- automatic highlighting and window position updates when 
         -- navigating the symboltree UI. Set to false to disable.
-        auto_highlight = true
+        auto_highlight = true,
     }
 
 ====================================================================================

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -146,6 +146,10 @@ function M.setup(user_config)
     -- will enable symboltree ui tracking with source code lines.
     vim.cmd([[au CursorHold * lua require('calltree.ui').source_tracking()]])
 
+    -- will clean out any tree data for a tab when closed. only necessary
+    -- when CTClose or STClose is not issued before a tab is closed.
+    vim.cmd([[au TabClosed * lua require('calltree.ui').on_tab_closed(vim.fn.expand('<afile>'))]])
+
     -- setup commands
     vim.cmd("command! CTOpen        lua require('calltree.ui').open_to('calltree')")
     vim.cmd("command! STOpen        lua require('calltree.ui').open_to('symboltree')")

--- a/lua/calltree/tree/tree.lua
+++ b/lua/calltree/tree/tree.lua
@@ -41,6 +41,12 @@ end
 --
 -- handle : tree_handle - a valid handle to a tree
 function M.remove_tree(handle)
+    if handle == nil then
+        return
+    end
+    if reg[handle] == nil then
+        return
+    end
     reg[handle] = nil
 end
 

--- a/lua/calltree/ui.lua
+++ b/lua/calltree/ui.lua
@@ -1,5 +1,4 @@
 local ct = require('calltree')
-local config = require('calltree').config
 local lsp_util = require('calltree.lsp.util')
 local ui_buf = require('calltree.ui.buffer')
 local ui_win = require('calltree.ui.window')
@@ -21,7 +20,7 @@ local direction_map = {
 }
 
 -- ui_state_registry is a registry of vim tabs mapped to calltree's
--- ui ui_state.
+-- ui state.
 --
 -- every tab can have its own UI ui_state.
 --
@@ -639,6 +638,15 @@ M.source_tracking = function ()
             return
         end
     end
+end
+
+M.on_tab_closed = function(tab)
+    local ui_state = M.ui_state_registry[tab]
+    if ui_state == nil then
+        return
+    end
+    tree.remove_tree(ui_state.calltree_handle)
+    tree.remove_tree(ui_state.symboltree_handle)
 end
 
 -- dumptree will dump the tree datastructure to a

--- a/lua/calltree/ui/buffer.lua
+++ b/lua/calltree/ui/buffer.lua
@@ -85,10 +85,6 @@ function M._setup_buffer(name, buffer_handle, tab, type)
         vim.cmd("au CursorHold <buffer=" .. buffer_handle .. "> lua require('calltree.ui').auto_highlight(true)")
     end
 
-    vim.cmd("command! CTJumpTab     lua require('calltree.ui').jump('tab')")
-    vim.cmd("command! CTJumpSplit   lua require('calltree.ui').jump('split')")
-    vim.cmd("command! CTJumpVSplit  lua require('calltree.ui').jump('vsplit')")
-
     -- set buffer local keymaps
     local close_cmd = nil
     if type == "calltree" then


### PR DESCRIPTION
under certain conditions closing a tab can leave around unused tree
data structures.

by adding an autocommand that fires on TabClosed event we ensure any
tree data structures associated with the closed tabs are removed from memory on next lua gc.

closes #44 

Signed-off-by: ldelossa <louis.delos@gmail.com>
