### PR TITLE
Scrolloff

### DIFF
--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -252,6 +252,13 @@ The config table is described below:
         -- automatic highlighting and window position updates when 
         -- navigating the symboltree UI. Set to false to disable.
         auto_highlight = true,
+        -- if set to true when navigating the symboltree outline 
+        -- the related symbol in the source code window will be placed
+        -- in the middle of the window.
+        --
+        -- the scrolloff is turned off once the cursor leaves the symboltree
+        -- outline.
+        scrolloff = false,
     }
 
 ====================================================================================

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -11,7 +11,8 @@ M.config = {
     icon_highlights = {},
     hls = {},
     resolve_symbols = true,
-    auto_highlight = true
+    auto_highlight = true,
+    scrolloff = false
 }
 
 function _setup_default_highlights() 

--- a/lua/calltree/lsp/util.lua
+++ b/lua/calltree/lsp/util.lua
@@ -2,7 +2,7 @@ local tree_node = require('calltree.tree.node')
 local notify = require('calltree.ui.notify')
 local M = {}
 
-M.multi_client_request = function(clients, method, params, handler, bufnr)
+function M.multi_client_request(clients, method, params, handler, bufnr)
     for _, client in ipairs(clients) do
         if not client.supports_method(method) then
             goto continue
@@ -24,20 +24,40 @@ function M.relative_path_from_uri(uri)
     return vim.fn.substitute(uri_path, cwd .. "/", "", ""), true
 end
 
-function M.resolve_file_path(node) 
+function M.absolute_path_from_uri(uri)
+    local uri_path = vim.fn.substitute(uri, "file://", "", "")
+    return uri_path
+end
+
+function M.resolve_relative_file_path(node)
     if node.symbol ~= nil then
-        uri = node.symbol.location.uri
+        local uri = node.symbol.location.uri
         return M.relative_path_from_uri(uri)
     elseif node.call_hierarchy_item ~= nil then
-        uri = node.call_hierarchy_item.uri
+        local uri = node.call_hierarchy_item.uri
         return M.relative_path_from_uri(uri)
     elseif node.document_symbol ~= nil then
-        uri = node.uri
+        local uri = node.uri
         return M.relative_path_from_uri(uri)
     else
         return nil
     end
 
+end
+
+function M.resolve_absolute_file_path(node)
+    if node.symbol ~= nil then
+        local uri = node.symbol.location.uri
+        return M.absolute_path_from_uri(uri)
+    elseif node.call_hierarchy_item ~= nil then
+        local uri = node.call_hierarchy_item.uri
+        return M.absolute_path_from_uri(uri)
+    elseif node.document_symbol ~= nil then
+        local uri = node.uri
+        return M.absolute_path_from_uri(uri)
+    else
+        return nil
+    end
 end
 
 function M.resolve_location(node)
@@ -194,7 +214,7 @@ end
 
 function M.gather_symbols_async(root, children, ui_state, callback)
     local co = nil
-    all_nodes = {}
+    local all_nodes = {}
     table.insert(all_nodes, root)
     for _, child in ipairs(children) do
         table.insert(all_nodes, child)

--- a/lua/calltree/ui.lua
+++ b/lua/calltree/ui.lua
@@ -554,11 +554,11 @@ M.details = function()
 
     ctx.state  = M.ui_state_registry[ctx.tab]
 
-    local direction = "symboltree"
+    local direction = ""
     if ctx.tree_type == "calltree" then
         direction = ctx.state.calltree_dir
     end
-    deets.details_popup(ctx.node, direction)
+    deets.details_popup(ctx.node, ctx.tree_type, direction)
 end
 
 -- auto_highlight will automatically highlight
@@ -610,14 +610,17 @@ M.source_tracking = function ()
 
     ctx.tree_handle = ctx.state.symboltree_handle
 
+
     -- if there's a direct match for this line, use this
+    local cur_file = vim.fn.expand('%:p')
+
     local source_map = marshal.source_line_map[ctx.tree_handle]
     if source_map == nil then
         return
     end
-    local line = source_map[ctx.linenr[1]]
-    if line ~= nil then
-            vim.api.nvim_win_set_cursor(ctx.state.symboltree_win, {line, 0})
+    local source = source_map[ctx.linenr[1]]
+    if source ~= nil and source.uri == cur_file then
+            vim.api.nvim_win_set_cursor(ctx.state.symboltree_win, {source.line, 0})
             vim.cmd("redraw!")
             return
     end
@@ -632,6 +635,7 @@ M.source_tracking = function ()
     for line, node in pairs(buf_lines) do
         if ctx.linenr[1] >= node.document_symbol.range["start"].line
             and ctx.linenr[1] <= node.document_symbol.range["end"].line
+                and cur_file == lsp_util.resolve_absolute_file_path(node)
         then
             vim.api.nvim_win_set_cursor(ctx.state.symboltree_win, {line, 0})
             vim.cmd("redraw!")

--- a/lua/calltree/ui/buffer.lua
+++ b/lua/calltree/ui/buffer.lua
@@ -10,6 +10,18 @@ function M.close_all_popups()
     require('calltree.ui.details').close_details_popup()
 end
 
+-- set_scrolloff will enable a global scrolloff
+-- of 999 when set is true.
+--
+-- when set is false the scrolloff will be set back to 0.
+function M.set_scrolloff(set)
+    if set then
+        vim.cmd("set scrolloff=999")
+    else
+        vim.cmd("set scrolloff=0")
+    end
+end
+
 local function map_resize_keys(buffer_handle, opts)
     local l = config.layout
     if l == "top" or l == "bottom"  then
@@ -83,6 +95,11 @@ function M._setup_buffer(name, buffer_handle, tab, type)
     if config.auto_highlight then
         vim.cmd("au BufWinLeave,WinLeave <buffer=" .. buffer_handle .. "> lua require('calltree.ui').auto_highlight(false)")
         vim.cmd("au CursorHold <buffer=" .. buffer_handle .. "> lua require('calltree.ui').auto_highlight(true)")
+    end
+
+    if config.scrolloff then
+        vim.cmd("au WinLeave <buffer=" .. buffer_handle .. "> lua require('calltree.ui.buffer').set_scrolloff(false)")
+        vim.cmd("au WinEnter <buffer=" .. buffer_handle .. "> lua require('calltree.ui.buffer').set_scrolloff(true)")
     end
 
     -- set buffer local keymaps

--- a/lua/calltree/ui/marshal.lua
+++ b/lua/calltree/ui/marshal.lua
@@ -36,7 +36,10 @@ M.buf_line_map = {}
 -- the struture of this table is as follows:
 -- {
 --   tree_handle = {
---      source_file_line_number = calltree_buffer_line_number
+--      source_file_line_number = {
+--          uri = relative_path_to_file,
+--          line = calltree_buffer_line_number
+--      }
 --      ...
 --   }
 --   ...
@@ -193,7 +196,10 @@ function M.marshal_tree(buf_handle, lines, node, tree, virtual_text_lines, final
     local loc = lsp_util.resolve_location(node)
     if loc ~= nil then
         local start_line = loc["range"]["start"].line
-        M.source_line_map[tree][start_line+1] = #lines
+        M.source_line_map[tree][start_line+1] = {
+            uri = lsp_util.resolve_absolute_file_path(node),
+            line = #lines
+        }
     end
 
     -- if we are an expanded node or we are the root (always expand)

--- a/lua/calltree/ui/notify.lua
+++ b/lua/calltree/ui/notify.lua
@@ -35,7 +35,7 @@ function M.notify_popup(text)
     vim.api.nvim_buf_set_lines(buf, 0, #lines, false, lines)
     vim.api.nvim_buf_set_option(buf, 'modifiable', false)
     local popup_conf = {
-        relative = "win",
+        relative = "editor",
         anchor = "SE",
         width = width,
         height = 1,
@@ -43,7 +43,8 @@ function M.notify_popup(text)
         zindex = 99,
         style = "minimal",
         border = "rounded",
-        bufpos = {999999999, -1}
+        row = vim.opt.lines:get() - (vim.opt.cmdheight:get() + 1),
+        col = vim.opt.columns:get(),
     }
     table.insert(float_wins, vim.api.nvim_open_win(buf, false, popup_conf))
 end


### PR DESCRIPTION
This pull adds a scrolloff feature which is optional. 
If enabled browsing the symboltree will cause the tracked source file to keep symbols in the middle of the source file page. 
Scrolloff feature is turned on only when inside the Symboltree and turned off when leaving it.

This pull also makes the notification popup a bit nicer by placing it in bottom right and taking status line into account.

Additionally this pull closes #48 by tracking the URI of the current source file in the editor.