### PR TITLE
feat: make mapping of cursor keys to resize optional

### DIFF
--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -259,6 +259,8 @@ The config table is described below:
         -- the scrolloff is turned off once the cursor leaves the symboltree
         -- outline.
         scrolloff = false,
+        -- map <Left>, <Right>, <Up>, <Down> to resize calltree/symboltree
+        map_resize_keys = true,
     }
 
 ====================================================================================

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -12,7 +12,8 @@ M.config = {
     hls = {},
     resolve_symbols = true,
     auto_highlight = true,
-    scrolloff = false
+    scrolloff = false,
+    map_resize_keys = true,
 }
 
 function _setup_default_highlights() 

--- a/lua/calltree/ui/buffer.lua
+++ b/lua/calltree/ui/buffer.lua
@@ -24,7 +24,7 @@ end
 
 local function map_resize_keys(buffer_handle, opts)
     local l = config.layout
-    if l == "top" or l == "bottom"  then
+    if l == "top" then
         vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Right>", ":vert resize +5<cr>", opts)
         vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Left>", ":vert resize -5<cr>", opts)
         vim.api.nvim_buf_set_keymap(buffer_handle, "n", "<Up>", ":resize +5<cr>", opts)
@@ -125,7 +125,9 @@ function M._setup_buffer(name, buffer_handle, tab, type)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "?", ":lua require('calltree.ui').help(true)<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "h", ":lua require('calltree.ui')._smart_close()<CR>", opts)
     vim.api.nvim_buf_set_keymap(buffer_handle, "n", "x", close_cmd, opts)
-    map_resize_keys(buffer_handle, opts)
+	if config.map_resize_keys then
+        map_resize_keys(buffer_handle, opts)
+    end
     return buffer_handle
 end
 


### PR DESCRIPTION
fix: resize keys for layout "bottom" were not bound correctly