### PR TITLE
feat: let toggle_panel return wether or not it opened the panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To start a calltree or a symboltree use the LSP client just like you're used to:
 ```
 :lua vim.lsp.buf.incoming_calls()
 :lua vim.lsp.buf.outgoing_calls()
-:lua vim.slp.buf.document_symbol() (symboltree outline)
+:lua vim.lsp.buf.document_symbol() (symboltree outline)
 ```
 
 You most likely have key mappings set for this if you're using the lsp-config.

--- a/lua/calltree/ui.lua
+++ b/lua/calltree/ui.lua
@@ -346,11 +346,16 @@ end
 --
 -- keep_open : bool - if true, and the panel is open,
 -- the panel will be left open when this function terminates.
+--
+-- returns:
+--  bool : true if panel is open after this call, false otherwise,
+--  if panel could not be opened returns `(nil, err)` where `err` is
+--  a string describing the failure reason
 M.toggle_panel = function(keep_open)
     local ctx = ui_req_ctx()
     if ctx.state == nil then
         notify.notify_popup_with_timeout("Cannot toggle panel until LSP method is called.", 1750, "error")
-        return
+        return nil, "Cannot toggle panel until LSP method is called."
     end
 
     if ctx.state.calltree_handle ~= nil then
@@ -376,7 +381,7 @@ M.toggle_panel = function(keep_open)
         ctx.state.symboltree_tab = ctx.tab
     end
 
-    ui_win._toggle_panel(ctx.state, keep_open)
+    return ui_win._toggle_panel(ctx.state, keep_open)
 end
 
 -- collapse will collapse a symbol at the current cursor

--- a/lua/calltree/ui/window.lua
+++ b/lua/calltree/ui/window.lua
@@ -99,6 +99,9 @@ end
 -- the panel is already open. Useful for LSP handlers
 -- which want to refresh the state of the UI but not
 -- close the panels.
+--
+-- returns:
+--  opened : bool - true if window is open after this call, false otherwise
 function M._toggle_panel(ui_state, keep_open)
     local cur_win = vim.api.nvim_get_current_win()
     local open = true
@@ -112,24 +115,21 @@ function M._toggle_panel(ui_state, keep_open)
             end
         end
         if not open then
-            return
+            return false
         end
     end
 
     -- we didn't find any open calltree windows, toggle
     -- the panel open
-    if 
-        ui_state.calltree_handle ~= nil
-    then
+    if ui_state.calltree_handle ~= nil then
         M._open_window("calltree", ui_state)
     end
-    if 
-        ui_state.symboltree_handle ~= nil
-    then
+    if ui_state.symboltree_handle ~= nil then
         M._open_window("symboltree", ui_state)
     end
 
     vim.api.nvim_set_current_win(cur_win)
+    return true
 end
 
 -- setup_window evaluates the current layout and the desired layout


### PR DESCRIPTION
Rationale behind this modification: I have bound a key to `toggle_panel()` but with recent changes this will no longer open the panel before I first called any of the LSP methods (before it just opened the symboltree and populated it).

With this change I can check if opening the panel was successful and if not call `vim.lsp.buf.document_symbol()` so it will eventually do what I want. ;-)