### PR TITLE
ui: hide cursor in calltree.nvim windows

### DIFF
--- a/doc/calltree.txt
+++ b/doc/calltree.txt
@@ -261,6 +261,14 @@ The config table is described below:
         scrolloff = false,
         -- map <Left>, <Right>, <Up>, <Down> to resize calltree/symboltree
         map_resize_keys = true,
+        -- if set to true the cursor will be hidden when inside a Calltree.nvim
+        -- window. 
+        --
+        -- this is done by setting guicursor to the same fg/bg as CursorLine hi
+        -- making it blend in with the CursorLine.
+        --
+        -- set your CursorLine hi correctly with cterm/gui values for this to work.
+        hide_cursor = false,
     }
 
 ====================================================================================

--- a/lua/calltree.lua
+++ b/lua/calltree.lua
@@ -14,6 +14,7 @@ M.config = {
     auto_highlight = true,
     scrolloff = false,
     map_resize_keys = true,
+    hide_cursor = false,
 }
 
 function _setup_default_highlights() 

--- a/lua/calltree/ui/help_buffer.lua
+++ b/lua/calltree/ui/help_buffer.lua
@@ -61,7 +61,7 @@ function M._setup_help_buffer(help_buf_handle)
             "S                  - switch the symbol from incoming/outgoing calls (call hierarchies)",
             "i                  - show hover info for symbol",
             "d                  - show symbol details",
-            "h                  - hide this element from the panel, will appear again on toggle",
+            "H                  - hide this element from the panel, will appear again on toggle",
             "x                  - remove this element from the panel, will not appear until another LSP request",
             "Up,Down,Right,Left - resize the panel"
         }


### PR DESCRIPTION
this commit adds an au which hides the cursor when entering a
calltree.nvim window and unhides it when exiting.

this is driven by the "hide_cursor" option which defaults to false.

Signed-off-by: ldelossa <louis.delos@gmail.com>