### PR TITLE
ui: display leafs and improve source tracking

### DIFF
--- a/lua/calltree/ui.lua
+++ b/lua/calltree/ui.lua
@@ -655,17 +655,21 @@ M.source_tracking = function ()
 
     -- no direct match for the line, so search for symbols with a range
     -- interval overlapping our line number.
+    --
+    -- we search in reverse since code is written top down, allows
+    -- for source_tracking to handle nested elements correctly.
     local buf_lines = marshal.buf_line_map[ctx.tree_handle]
     if buf_lines == nil then
         return
     end
 ---@diagnostic disable-next-line: redefined-local
-    for line, node in pairs(buf_lines) do
+    for i=#buf_lines,1,-1 do
+        local node = buf_lines[i]
         if ctx.linenr[1] >= node.document_symbol.range["start"].line
             and ctx.linenr[1] <= node.document_symbol.range["end"].line
                 and cur_file == lsp_util.resolve_absolute_file_path(node)
         then
-            vim.api.nvim_win_set_cursor(ctx.state.symboltree_win, {line, 0})
+            vim.api.nvim_win_set_cursor(ctx.state.symboltree_win, {i, 0})
             vim.cmd("redraw!")
             return
         end

--- a/lua/calltree/ui/marshal.lua
+++ b/lua/calltree/ui/marshal.lua
@@ -54,11 +54,11 @@ M.source_line_map = {}
 --    table  - a virt_text chunk that can be passed directly to
 -- vim.api.nvim_buf_set_extmark() via the virt_text option.
 function M.marshal_node(node, final)
-    local glyph = ""
+    local expand_guide = ""
     if node.expanded then
-        glyph = M.glyphs["expanded"]
+        expand_guide = M.glyphs["expanded"]
     else
-        glyph = M.glyphs["collapsed"]
+        expand_guide = M.glyphs["collapsed"]
     end
 
     -- prefer using workspace symbol details if available.
@@ -74,6 +74,13 @@ function M.marshal_node(node, final)
         elseif node.symbol.detail ~= nil then
             detail = node.symbol.detail
         end
+        if
+            #node.children == 0
+            and node.expanded == true
+        then
+        -- we are at a leaf, no guide necessary.
+            expand_guide = M.glyphs["space"]
+         end
     elseif node.document_symbol ~= nil then
         name = node.document_symbol.name
         kind = vim.lsp.protocol.SymbolKind[node.document_symbol.kind]
@@ -82,7 +89,7 @@ function M.marshal_node(node, final)
             detail = node.document_symbol.detail
         end
         if #node.children == 0 then
-            glyph = M.glyphs.space
+            expand_guide = M.glyphs.space
         end
     elseif node.call_hierarchy_item ~= nil then
         name = node.name
@@ -119,7 +126,7 @@ function M.marshal_node(node, final)
     end
 
     -- ▶ Func1
-    str = str .. glyph .. M.glyphs.space
+    str = str .. expand_guide .. M.glyphs.space
 
     if ct.config.icons ~= "none" then
         -- ▶   Func1


### PR DESCRIPTION
this commit now displays "leafs" by removing any expanded guides for
calltree elements.

additionally, we now perform source code tracking bottom up in order to
handle nested elements correctly.

Signed-off-by: ldelossa <louis.delos@gmail.com>